### PR TITLE
Fix the detection of the JSONC library which does not validate UTF-8

### DIFF
--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -281,7 +281,7 @@ class JsonDecoder
     {
         $assoc = self::ASSOC_ARRAY === $this->objectDecoding;
 
-        if (version_compare(PHP_VERSION, '5.4.0', '>=') && false === strpos(PHP_VERSION, 'ubuntu')) {
+        if (PHP_VERSION_ID >= 50400 && !defined('JSON_C_VERSION')) {
             $options = self::STRING === $this->bigIntDecoding ? JSON_BIGINT_AS_STRING : 0;
 
             $decoded = json_decode($json, $assoc, $this->maxDepth, $options);

--- a/tests/JsonDecoderTest.php
+++ b/tests/JsonDecoderTest.php
@@ -113,10 +113,8 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecodeFailsIfNotUtf8()
     {
-        if (false !== strpos(PHP_VERSION, 'ubuntu')) {
-            $this->markTestSkipped('This error is not reported on PHP versions compiled for Ubuntu.');
-
-            return;
+        if (defined('JSON_C_VERSION')) {
+            $this->markTestSkipped('This error is not reported when using JSONC.');
         }
 
         $win1258 = file_get_contents($this->fixturesDir.'/win-1258.json');
@@ -315,10 +313,8 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecodeFileFailsIfNotUtf8()
     {
-        if (false !== strpos(PHP_VERSION, 'ubuntu')) {
-            $this->markTestSkipped('This error is not reported on PHP versions compiled for Ubuntu.');
-
-            return;
+        if (defined('JSON_C_VERSION')) {
+            $this->markTestSkipped('This error is not reported when using JSONC.');
         }
 
         $this->decoder->decodeFile($this->fixturesDir.'/win-1258.json');


### PR DESCRIPTION
Affected systems don't always have ``ubuntu`` in their version name