### PR TITLE
Fix the decoding of 'null', which is not an error

### DIFF
--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -290,7 +290,7 @@ class JsonDecoder
         }
 
         // Data could not be decoded
-        if (null === $decoded && null !== $json) {
+        if (null === $decoded && 'null' !== $json) {
             $parser = new JsonParser();
             $e = $parser->lint($json);
 

--- a/tests/JsonDecoderTest.php
+++ b/tests/JsonDecoderTest.php
@@ -55,6 +55,13 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\stdClass', $data);
     }
 
+    public function testDecodeNull()
+    {
+        $data = $this->decoder->decode('null');
+
+        $this->assertNull($data);
+    }
+
     public function testDecodeNestedEmptyObject()
     {
         $data = $this->decoder->decode('{ "empty": {} }');


### PR DESCRIPTION
The json-encoded version of ``null`` is not ``null``, but the string ``'null'``