### PR TITLE
Switch to the docker-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,13 @@ matrix:
   allow_failures:
     - php: 7.0
 
-before_script: composer install -n
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install: composer install -n
 
 script: vendor/bin/phpunit -v --coverage-clover=coverage.clover
 


### PR DESCRIPTION
The composer cache will also make the install faster by reusing the same dist archives between builds 