### PR TITLE
fixed legacy(?) method name

### DIFF
--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -100,7 +100,7 @@ class JsonDecoder
             throw new \InvalidArgumentException(
                 'Schema validation is not supported when objects are decoded '.
                 'as associative arrays. Call '.
-                'JsonDecoder::setDecodeObjectsAs(JsonDecoder::JSON_OBJECT) to fix.'
+                'JsonDecoder::setObjectDecoding(JsonDecoder::JSON_OBJECT) to fix.'
             );
         }
 


### PR DESCRIPTION
`JsonDecoder::setDecodeObjectsAs()` does not exist