### PR TITLE
Support justinrainbow/json-schema 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^5.3.3|^7.0",
-        "justinrainbow/json-schema": "^1.6",
+        "justinrainbow/json-schema": "^1.6|^2.0",
         "seld/jsonlint": "^1.0",
         "webmozart/assert": "^1.0",
         "webmozart/path-util": "^2.3"


### PR DESCRIPTION
Follow up for #18, which supports both major versions.

The tests fail with 1.x, but these failures seem to have already existed. (The tests seem to now pass with 2.x.)