### PR TITLE
Added support for empty properties (fixes #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
  * added support for `$ref` to external schema
  * added support for validation against `$schema` property
  * added `LocalUriRetriever`
+ * added support for empty properties before PHP 7.1
 
 * 1.2.2 (2016-01-14)
 

--- a/src/JsonEncoder.php
+++ b/src/JsonEncoder.php
@@ -178,6 +178,21 @@ class JsonEncoder
             }
         }
 
+        if (PHP_VERSION_ID < 71000) {
+            // PHP before 7.1 decodes empty properties as "_empty_". Make
+            // sure the encoding of these properties works again.
+            if (is_object($data) && isset($data->{'_empty_'})) {
+                $data = (array) $data;
+            }
+
+            if (is_array($data) && isset($data['_empty_'])) {
+                // Maintain key order
+                $keys = array_keys($data);
+                $keys[array_search('_empty_', $keys, true)] = '';
+                $data = array_combine($keys, $data);
+            }
+        }
+
         if (PHP_VERSION_ID >= 50500) {
             $maxDepth = $this->maxDepth;
 

--- a/tests/JsonDecoderTest.php
+++ b/tests/JsonDecoderTest.php
@@ -148,6 +148,54 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name' => 'Bernhard'), $decoded);
     }
 
+    public function testDecodeEmptyArrayKey()
+    {
+        $data = array('' => 'Bernhard');
+
+        $this->decoder->setObjectDecoding(JsonDecoder::ASSOC_ARRAY);
+
+        $this->assertEquals($data, $this->decoder->decode('{"":"Bernhard"}'));
+    }
+
+    public function testDecodeEmptyProperty()
+    {
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $this->markTestSkipped('PHP >= 7.1.0 only');
+
+            return;
+        }
+
+        $data = (object) array('' => 'Bernhard');
+
+        $this->assertEquals($data, $this->decoder->decode('{"":"Bernhard"}'));
+    }
+
+    public function testDecodeMagicEmptyPropertyAfter71()
+    {
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $this->markTestSkipped('PHP >= 7.1.0 only');
+
+            return;
+        }
+
+        $data = (object) array('_empty_' => 'Bernhard');
+
+        $this->assertEquals($data, $this->decoder->decode('{"_empty_":"Bernhard"}'));
+    }
+
+    public function testDecodeMagicEmptyPropertyBefore71()
+    {
+        if (version_compare(PHP_VERSION, '7.1.0', '>=')) {
+            $this->markTestSkipped('PHP < 7.1.0 only');
+
+            return;
+        }
+
+        $data = (object) array('a' => 'b', '_empty_' => 'Bernhard', 'c' => 'd');
+
+        $this->assertEquals($data, $this->decoder->decode('{"a":"b","":"Bernhard","c":"d"}'));
+    }
+
     public function provideInvalidObjectDecoding()
     {
         return array(

--- a/tests/JsonEncoderTest.php
+++ b/tests/JsonEncoderTest.php
@@ -151,6 +151,52 @@ class JsonEncoderTest extends \PHPUnit_Framework_TestCase
         $this->encoder->encode(self::BINARY_INPUT);
     }
 
+    public function testEncodeEmptyArrayKey()
+    {
+        $data = array('' => 'Bernhard');
+
+        $this->assertSame('{"":"Bernhard"}', $this->encoder->encode($data));
+    }
+
+    public function testEncodeEmptyProperty()
+    {
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $this->markTestSkipped('PHP >= 7.1.0 only');
+
+            return;
+        }
+
+        $data = (object) array('' => 'Bernhard');
+
+        $this->assertSame('{"":"Bernhard"}', $this->encoder->encode($data));
+    }
+
+    public function testEncodeMagicEmptyPropertyAfter71()
+    {
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $this->markTestSkipped('PHP >= 7.1.0 only');
+
+            return;
+        }
+
+        $data = (object) array('_empty_' => 'Bernhard');
+
+        $this->assertSame('{"_empty_":"Bernhard"}', $this->encoder->encode($data));
+    }
+
+    public function testEncodeMagicEmptyPropertyBefore71()
+    {
+        if (version_compare(PHP_VERSION, '7.1.0', '>=')) {
+            $this->markTestSkipped('PHP < 7.1.0 only');
+
+            return;
+        }
+
+        $data = (object) array('a' => 'b', '_empty_' => 'Bernhard', 'c' => 'd');
+
+        $this->assertSame('{"a":"b","":"Bernhard","c":"d"}', $this->encoder->encode($data));
+    }
+
     public function testEncodeArrayAsArray()
     {
         $data = array('one', 'two');


### PR DESCRIPTION
This PR adds support for empty properties before PHP 7.1. Before that version, empty properties are decoded as `_empty_`:

~~~php
$decoded = $decoder->decode('{"":"Foobar"}');

var_dump($decoded);

// stdClass('_empty_' => 'Foobar')
~~~

However, when encoding the same object again, PHP does not convert the `_empty_` property back:

~~~php
var_dump($encoder->encode($decoded));

// {"_empty_":"Foobar"}
~~~

This is problematic if you want to load and write files with empty keys on a lower version than PHP 7.1.

This PR fixes the `JsonEncoder` below 7.1 to convert `_empty_` properties to "", hence the following condition holds on all supported PHP versions:

~~~php
'{"":"Foobar"}' === $encoder->encode($decoder->decode('{"":"Foobar"}'));
~~~