### PR TITLE
Always validate against $schema property

### DIFF
--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -108,11 +108,7 @@ class JsonDecoder
 
         $data = $this->decodeJson($json);
 
-        if (null === $schema && isset($data->{'$schema'})) {
-            $schema = $data->{'$schema'};
-        }
-
-        if (null !== $schema) {
+        if (null !== $schema || isset($data->{'$schema'})) {
             $errors = $this->validator->validate($data, $schema);
 
             if (count($errors) > 0) {

--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -106,17 +106,21 @@ class JsonDecoder
             );
         }
 
-        $decoded = $this->decodeJson($json);
+        $data = $this->decodeJson($json);
+
+        if (null === $schema && isset($data->{'$schema'})) {
+            $schema = $data->{'$schema'};
+        }
 
         if (null !== $schema) {
-            $errors = $this->validator->validate($decoded, $schema);
+            $errors = $this->validator->validate($data, $schema);
 
             if (count($errors) > 0) {
                 throw ValidationFailedException::fromErrors($errors);
             }
         }
 
-        return $decoded;
+        return $data;
     }
 
     /**

--- a/src/JsonEncoder.php
+++ b/src/JsonEncoder.php
@@ -130,6 +130,10 @@ class JsonEncoder
      */
     public function encode($data, $schema = null)
     {
+        if (null === $schema && isset($data->{'$schema'})) {
+            $schema = $data->{'$schema'};
+        }
+
         if (null !== $schema) {
             $errors = $this->validator->validate($data, $schema);
 

--- a/src/JsonEncoder.php
+++ b/src/JsonEncoder.php
@@ -130,11 +130,7 @@ class JsonEncoder
      */
     public function encode($data, $schema = null)
     {
-        if (null === $schema && isset($data->{'$schema'})) {
-            $schema = $data->{'$schema'};
-        }
-
-        if (null !== $schema) {
+        if (null !== $schema || isset($data->{'$schema'})) {
             $errors = $this->validator->validate($data, $schema);
 
             if (count($errors) > 0) {


### PR DESCRIPTION
From the README:

> By default, the JSON schema stored in the $schema property of the JSON document is used to validate the file.

However, it doesn't look like this is actually happening. This PR fixes that.